### PR TITLE
Create a bucket for CF access logging

### DIFF
--- a/cloudfront-logging.tf
+++ b/cloudfront-logging.tf
@@ -1,0 +1,60 @@
+data "aws_canonical_user_id" "current" {}
+data "aws_cloudfront_log_delivery_canonical_user_id" "cf" {}
+
+
+resource "aws_s3_bucket" "cloudfront_logging" {
+  bucket_prefix = "pyspy-cf"
+}
+
+resource "aws_s3_bucket_ownership_controls" "cloudfront_logging" {
+  bucket = aws_s3_bucket.cloudfront_logging.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_acl" "cloudfront_logging" {
+  bucket = aws_s3_bucket.cloudfront_logging.id
+
+  access_control_policy {
+    grant {
+      grantee {
+        id   = data.aws_cloudfront_log_delivery_canonical_user_id.cf.id
+        type = "CanonicalUser"
+      }
+      permission = "FULL_CONTROL"
+    }
+    owner {
+      id = data.aws_canonical_user_id.current.id
+    }
+  }
+  depends_on = [aws_s3_bucket_ownership_controls.cloudfront_logging]
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "cloudfront_expiration" {
+  bucket = aws_s3_bucket.cloudfront_logging.id
+
+  rule {
+    id = "Expiration"
+
+    filter {}
+
+    status = "Enabled"
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+
+    expiration {
+      days = 30
+    }
+
+  }
+}
+# Block all public access (recommended)
+resource "aws_s3_bucket_public_access_block" "cf_logs" {
+  bucket                  = aws_s3_bucket.cloudfront_logging.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -69,6 +69,11 @@ resource "aws_cloudfront_distribution" "distribution" {
       restriction_type = "none"
     }
   }
+
+  logging_config {
+    include_cookies = false
+    bucket          = aws_s3_bucket.cloudfront_logging.bucket_domain_name
+  }
 }
 
 resource "aws_cloudfront_cache_policy" "pyspy" {

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -73,6 +73,7 @@ resource "aws_cloudfront_distribution" "distribution" {
   logging_config {
     include_cookies = false
     bucket          = aws_s3_bucket.cloudfront_logging.bucket_domain_name
+    prefix          = "cloudfront/"
   }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled CDN access logging for improved visibility into traffic patterns and troubleshooting.
  * Logs delivered to a dedicated, secure storage bucket with enforced ownership, ACLs, and public-access blocks.
  * Automatic log retention: 30 days, with older logs expired to manage storage costs.
  * Cookies excluded from logs to reduce sensitive data capture.
  * No changes to content delivery or end-user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->