### PR TITLE
Allow access by owning user

### DIFF
--- a/cloudfront-logging.tf
+++ b/cloudfront-logging.tf
@@ -19,14 +19,24 @@ resource "aws_s3_bucket_acl" "cloudfront_logging" {
   access_control_policy {
     grant {
       grantee {
+        id   = data.aws_canonical_user_id.current.id
+        type = "CanonicalUser"
+      }
+      permission = "FULL_CONTROL"
+    }
+
+    grant {
+      grantee {
         id   = data.aws_cloudfront_log_delivery_canonical_user_id.cf.id
         type = "CanonicalUser"
       }
       permission = "FULL_CONTROL"
     }
+
     owner {
       id = data.aws_canonical_user_id.current.id
     }
+
   }
   depends_on = [aws_s3_bucket_ownership_controls.cloudfront_logging]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Set the logging bucket owner to the current account and granted it full control, ensuring consistent management of CloudFront access logs.
  - Kept CloudFront log delivery permissions intact so log ingestion continues without interruption.

- Chores
  - Updated logging configuration to align ownership and access controls with the current account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->